### PR TITLE
Upgrade to openai==1.55.3

### DIFF
--- a/opencopilot/requirements.txt
+++ b/opencopilot/requirements.txt
@@ -1,4 +1,4 @@
-openai~=1.17.0
+openai==1.55.3
 termcolor~=2.3.0
 jinja2~=3.1.2
 pydantic~=1.10.7


### PR DESCRIPTION
https://github.com/langchain-ai/langchain/issues/1986

https://community.openai.com/t/azureopenai-client-typeerror-client-init-got-an-unexpected-keyword-argument-proxies/1035218/9