### PR TITLE
Only update task status by the plan executor

### DIFF
--- a/opencopilot/controller/operators_executor.py
+++ b/opencopilot/controller/operators_executor.py
@@ -10,7 +10,6 @@ class OperatorExecutor(ABC):
 
     @staticmethod
     def finalize(task_context, result):
-        task_context.tasks[task_context.task_index][constants.Status] = constants.DONE
         task_context.tasks[task_context.task_index][constants.Result] = result
 
     @staticmethod


### PR DESCRIPTION
It is already handled in `receive_and_route_user_request`. Updating the status in two places might later cause race conflicts and race conditions. It it better to be handled by the plan executor, as it has better sight and control over the execution of tasks.